### PR TITLE
Bug fixed #15 Unable to package this project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <spring-data-jpa.version>1.5.0.RELEASE</spring-data-jpa.version>
         <spring-data-mongodb.version>1.4.1.RELEASE</spring-data-mongodb.version>
         <spring-boot.version>1.0.0.RC4</spring-boot.version>
-        <hibernate-jpa.version>1.0.0.FINAL</hibernate-jpa.version>
+        <hibernate-jpa.version>1.0.0.Final</hibernate-jpa.version>
 
         <servlet-api.version>3.0.1</servlet-api.version>
         <javassist.version>3.18.0-GA</javassist.version>


### PR DESCRIPTION
There is a case problem with hibernate-jpa version so (at least) in case sensitive OS (such as Linux), there is a 409 conflict while trying to download 1.0.0.FINAL (because the pom itself contains a different version: 1.0.0.Final).

In maven local repositories, 2 distinct folders are created (1.0.0.Final and 1.0.0.FINAL).
Changing the case is solving the problem.
