### PR TITLE
Fix Issue #24 (https://github.com/jhipster/jhipster-loaded/issues/24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 agent/*.iml
 common/*.iml
 reloader/*.iml
+target/

--- a/core/src/main/java/io/github/jhipster/loaded/JHipsterFileSystemWatcher.java
+++ b/core/src/main/java/io/github/jhipster/loaded/JHipsterFileSystemWatcher.java
@@ -86,6 +86,9 @@ public class JHipsterFileSystemWatcher implements FileSystemWatcher, Runnable {
                 public void run() {
                     JHipsterFileSystemWatcher.isStarted = false;
                     try {
+                        // Interrupt the thread which should interrupt the blocking wait calls
+                        // on the watcher queue.
+                        thread.interrupt();
                         thread.join();
                     } catch (InterruptedException e) {
                         log.error("Failed during the JVM shutdown", e);

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.jhipster.loaded</groupId>
     <artifactId>jhipster</artifactId>
-    <version>0.12-SNAPSHOT</version>
+    <version>0.13-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Ensure that interrupt is called on the watcher thread to kill it (as I saw some catches for interrupted exception). Also fix the pom.xml as there is already a 0.12 released and ignore target/ directories in git.
